### PR TITLE
Fixes Edit/Cancel to return to Gigs Mgt screen

### DIFF
--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -53,6 +53,7 @@ class GigsController < ApplicationController
 
   def require_admin
     return if current_user.admin?
+
     flash.alert = I18n.t('.must_be_admin')
     redirect_to root_path
   end

--- a/app/views/gigs/_form.html.slim
+++ b/app/views/gigs/_form.html.slim
@@ -17,4 +17,4 @@
 
   .form-actions
     = f.button :submit, button_name
-    = link_to "Cancel", schedule_path
+    = link_to "Cancel", gigs_path


### PR DESCRIPTION
When cancel button is clicked in Edit Gig, it now goes to Gigs Mgt page and not the Schedule page.