### PR TITLE
Feature/trim leading/trailing spaces from Copy menu entries

### DIFF
--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -60,10 +60,14 @@ class GigsController < ApplicationController
   end
 
   def regularize_names(gigs)
-    gigs = gigs.filter{ |g| !g.name.match?(/cancelled|canceled/i)}.each do |g|
-      g.name = g.name.gsub(/^\[/, "").gsub(/].*$/, "")
+    front_bracket = /^\[/
+    rest_of_bracket = /].*$/
+    digit_words = /\d+ */
+
+    gigs = gigs.filter { |g| !g.name.match?(/cancelled|canceled/i) }.each do |g|
+      g.name = g.name.gsub(front_bracket, "").gsub(rest_of_bracket, "").gsub(digit_words, "")
     end
-    gigs.sort_by(&:name).uniq{ |g| g.name.downcase }
+    gigs.sort_by(&:name).uniq { |g| g.name.downcase }.sort_by { |g| g.name.downcase }
   end
 
   def require_admin

--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -60,12 +60,12 @@ class GigsController < ApplicationController
   end
 
   def regularize_names(gigs)
-    front_bracket = /^\[/
+    front_bracket = /\[/
     rest_of_bracket = /].*$/
     digit_words = /\d+ */
 
     gigs = gigs.filter { |g| !g.name.match?(/cancelled|canceled/i) }.each do |g|
-      g.name = g.name.gsub(front_bracket, "").gsub(rest_of_bracket, "").gsub(digit_words, "")
+      g.name = g.name.gsub(front_bracket, "").gsub(rest_of_bracket, "").gsub(digit_words, "").strip
     end
     gigs.sort_by(&:name).uniq { |g| g.name.downcase }.sort_by { |g| g.name.downcase }
   end

--- a/app/models/gig.rb
+++ b/app/models/gig.rb
@@ -11,7 +11,6 @@ class Gig < ApplicationRecord
   scope :published,  -> { where(published: true) }
   scope :ascending,  -> { order(date: :asc) }
   scope :descending, -> { order(date: :desc) }
-  scope :unique,     -> { order(name: :asc).uniq(&:name) }
   scope :expired,    -> { where("date + days < ?", Time.zone.today) }
   scope :active,     -> { where("date + days >= ?", Time.zone.today) }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,21 +61,22 @@ unless Rails.env == "production"
   12.times do |n|
     # Always one New Years gig; we vary the casing so that we can check for proper operation
     # of the clone menu reducing code (no case insensitive dups)
+    date = Date.today.years_ago(n)
     Gig.create!(
       published: true,
-      date: Date.today.years_ago(n).beginning_of_year,
+      date: date.beginning_of_year,
       days: rand(6).round,
       # name: "#{Faker::Commerce.product_name} #{day_type}",
 
-      name: "[#{%w[New new nEw neW nEW].sample} Years Day Celebration](#{Faker::Internet.url})",
+      name: "[#{date.year} #{%w[New new nEw neW nEW].sample} Years Day Celebration](#{Faker::Internet.url})",
       location: "#{Faker::Address.city}, #{Faker::Address.state_abbr}" )
 
     # Always one New Years Eve gig
     Gig.create!(
       published: true,
-      date: Date.today.years_ago(n).end_of_year,
+      date: date.end_of_year,
       days: rand(6).round,
-      name: "[#{%w[New new nEw neW nEW].sample} Years Eve Party](#{Faker::Internet.url})",
+      name: "[#{%w[New new nEw neW nEW].sample} Years Eve #{date.year} Party](#{Faker::Internet.url})",
       location: "#{Faker::Address.city}, #{Faker::Address.state_abbr}" )
 
     # Always one cancelled gig

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,7 +60,10 @@ unless Rails.env == "production"
 
   12.times do |n|
     # Always one New Years gig; we vary the casing so that we can check for proper operation
-    # of the clone menu reducing code (no case insensitive dups)
+    # of the clone menu reducing code:
+    #   * no case insensitive dups
+    #   * digit words (i.e., years, and ordinals)
+    #   * leading and trailing spaces
     date = Date.today.years_ago(n)
     Gig.create!(
       published: true,
@@ -68,7 +71,7 @@ unless Rails.env == "production"
       days: rand(6).round,
       # name: "#{Faker::Commerce.product_name} #{day_type}",
 
-      name: "[#{date.year} #{%w[New new nEw neW nEW].sample} Years Day Celebration](#{Faker::Internet.url})",
+      name: "   [#{date.year} #{%w[New new nEw neW nEW].sample} Years Day Celebration](#{Faker::Internet.url})  123",
       location: "#{Faker::Address.city}, #{Faker::Address.state_abbr}" )
 
     # Always one New Years Eve gig
@@ -76,7 +79,7 @@ unless Rails.env == "production"
       published: true,
       date: date.end_of_year,
       days: rand(6).round,
-      name: "[#{%w[New new nEw neW nEW].sample} Years Eve #{date.year} Party](#{Faker::Internet.url})",
+      name: "   [#{%w[New new nEw neW nEW].sample} Years Eve #{date.year} Party](#{Faker::Internet.url}) 345",
       location: "#{Faker::Address.city}, #{Faker::Address.state_abbr}" )
 
     # Always one cancelled gig

--- a/features/steps/gig_management.rb
+++ b/features/steps/gig_management.rb
@@ -191,9 +191,9 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
 
   step 'there is at least one unpublished one-day gig dated two days ago' do
     @unpublished_gig = FactoryBot.create(:gig,
-                                          published: false,
-                                          days: 1,
-                                          date: Time.zone.today - 2)
+                                         published: false,
+                                         days: 1,
+                                         date: Time.zone.today - 2)
   end
 
   step 'I see the published gig is expired' do


### PR DESCRIPTION
After removing digit words there are sometimes leading or trailing spaces in the names that affect sorting.  This PR fixes them.