### PR TITLE
Fixes button styling for misc buttons

### DIFF
--- a/app/assets/stylesheets/semantic_style.scss
+++ b/app/assets/stylesheets/semantic_style.scss
@@ -675,6 +675,7 @@ form {
 // Rails button_to styling
 .button_to {
   display: inline;
+
   input {
     margin-top: 1rem;
     margin-bottom: 0;
@@ -685,14 +686,7 @@ form {
     padding: $button-left-right-pad;
   }
 
-  .add {
-    background: $article-bkg-color;
-    color: $link-color;
-    padding: 0 1.5rem;
-    margin: .2rem .2rem .2rem 0;
-  }
-
-  .copy {
+  .add, .copy, .misc {
     background: $article-bkg-color;
     color: $link-color;
     padding: 0 1.5rem;

--- a/app/views/gigs/_form.html.slim
+++ b/app/views/gigs/_form.html.slim
@@ -13,8 +13,8 @@
     = f.input :name, placeholder: "[event name](and link), plus optional other info"
     = f.input :note, placeholder: "optional additional information"
     = f.input :location, placeholder: "optional City, ST"
-    = f.input :published
+    = f.input :published, inline_label: " Published"
 
-  .form-actions
-    = f.button :submit, button_name
+  .form-actions.button_to
+    = f.button :submit, button_name, class: "misc"
     = link_to "Cancel", gigs_path

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -9,10 +9,10 @@
       start_year: 2010, end_year: Date.today.year + 1, selected: @user.band_start_date
     = f.input :password, required: if_new, autocomplete: "off", label: "New Password", hint: "leave it blank if you don't want to change it"
     = f.input :password_confirmation, required: if_new, label: "Confirm New Password"
-    = f.input :admin
+    = f.input :admin, inline_label: " Admin"
 
-  .form-actions
-    = f.button :submit, button_name
+  .form-actions.button_to
+    = f.button :submit, button_name, class: "misc"
     - if @user.persisted?
       = link_to "Cancel", users_path
     -else


### PR DESCRIPTION
Miscellaneous buttons were oversized compared to recent changed that shrank most other buttons.

This PR fixes that.  It also adds a space between the checkbox and the "Admin" label in Pirate Edit pages and the checkbox and "Published" label in Edit Gig pages. .