### PR TITLE
Disables the photos page (for now)

### DIFF
--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -64,11 +64,11 @@ section.details.container.simple-print
 
     .one-third.column
       article
-        = link_to photos_path, class: "image featured"
-          = image_tag "photos.jpg", alt: "Photos picture"
-          header.content
-            h2 Photo Gallery
-            p Albums showcasing the Tones' performance history - and the many friends they've made (and occasionally corrupted) along the way.
+        / = link_to photos_path, class: "image featured"
+        = image_tag "photos.jpg", alt: "Photos picture", class: "image featured"
+        header.content
+          h2 Photo Gallery
+          p Albums showcasing the Tones' performance history - and the many friends they've made (and occasionally corrupted) along the way.
 
     .one-third.column
       article


### PR DESCRIPTION
The Photos Page no longer displays FB galleries and needs to be revisited.  For the meantime, disable it.